### PR TITLE
set gateway to empty for vnet-n2

### DIFF
--- a/tn_template_lib/loadcore_open5gs_vm.yaml
+++ b/tn_template_lib/loadcore_open5gs_vm.yaml
@@ -15,8 +15,8 @@ trial_network:
       one_vnet_first_ip: "10.10.10.1"
       one_vnet_netmask: "255.255.255.0"
       one_vnet_address_size: 254
-      one_vnet_gw: "10.10.10.1"
-      one_vnet_dns: "1.1.1.1"
+      one_vnet_gw: "" # there is no gateway in this network
+      one_vnet_dns: "" # there is no DNS in this network
   # vnet-n3:
   #   type: "vnet"
   #   name: "n3"
@@ -26,8 +26,8 @@ trial_network:
   #     one_vnet_first_ip: "10.10.11.1"
   #     one_vnet_netmask: "255.255.255.0"
   #     one_vnet_address_size: 254
-  #     one_vnet_gw: "10.10.11.1"
-  #     one_vnet_dns: "1.1.1.1"
+  #     one_vnet_gw: "" # there is no gateway in this network
+  #     one_vnet_dns: "" # there is no DNS in this network
   open5gs_vm-core:
     type: "open5gs_vm"
     name: "core"


### PR DESCRIPTION
N2 and N3 networks dont have a gateway in this deployment.
The components will try to use the gateway for communication with Internet and jenkins which will fail as there is no gateway on the `.1` address.