### PR TITLE
fix(jenkins): guard against None lastSuccessfulBuild before subscript

### DIFF
--- a/core/jenkins/jenkins_handler.py
+++ b/core/jenkins/jenkins_handler.py
@@ -222,12 +222,10 @@ class JenkinsHandler:
                 message=build_console_output,
                 lines_to_remove=build_console_num_lines_aux,
             )
-            if (
-                self.jenkins_client.get_job_info(name=jenkins_deploy_pipeline)[
-                    "lastSuccessfulBuild"
-                ]["number"]
-                != next_build_number
-            ):
+            last_successful = self.jenkins_client.get_job_info(
+                name=jenkins_deploy_pipeline
+            )["lastSuccessfulBuild"]
+            if last_successful is None or last_successful["number"] != next_build_number:
                 raise JenkinsError(
                     message=(f"{build_console_output}"),
                     status_code=500,
@@ -359,12 +357,10 @@ class JenkinsHandler:
             f"{build_console_output}"
             "------------------------------------------------------------------------------------------------------------------"
         )
-        if (
-            self.jenkins_client.get_job_info(name=jenkins_destroy_pipeline)[
-                "lastSuccessfulBuild"
-            ]["number"]
-            != next_build_number
-        ):
+        last_successful = self.jenkins_client.get_job_info(
+            name=jenkins_destroy_pipeline
+        )["lastSuccessfulBuild"]
+        if last_successful is None or last_successful["number"] != next_build_number:
             raise JenkinsError(
                 message=(f"{build_console_output}"),
                 status_code=500,


### PR DESCRIPTION
## Summary

- `get_job_info()["lastSuccessfulBuild"]` returns `None` when a Jenkins job has never had a successful build
- The previous code subscripted `["number"]` directly on that value, raising `TypeError: 'NoneType' object is not subscriptable` and returning a 500 to the caller
- Fix: extract to a variable and check `is None` before comparing the build number — both in `deploy_trial_network()` and `destroy_trial_network()`

## Test plan

- [ ] Activate a TN whose Jenkins pipeline has never had a successful build; expect a clean `JenkinsError` (build console output in message) instead of a 500 TypeError
- [ ] Activate a TN normally; confirm happy path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)